### PR TITLE
[Feat] CUSER_009 완료, BUSER_007 완료

### DIFF
--- a/src/main/java/com/fiiiiive/zippop/common/responses/BaseResponseMessage.java
+++ b/src/main/java/com/fiiiiive/zippop/common/responses/BaseResponseMessage.java
@@ -21,6 +21,7 @@ public enum BaseResponseMessage {
     MEMBER_REGISTER_FAIL_PASSWORD_FORMAT(false, 2006, "패스워드 형식이 맞지 않습니다."),
     MEMBER_REGISTER_FAIL_PASSWORD_COMPLEXITY(false, 2007, "복잡한 패스워드를 사용해주세요"),
     MEMBER_REGISTER_FAIL_NAME_EMPTY(false, 2008, "이름을 입력해주세요"),
+    MEMBER_REGISTER_FAIL_ALREADY_EXIST(false, 2009, "이미 회원가입한 계정입니다."),
     // 이메일 인증 2010
     MEMBER_EMAIL_VERIFY_SUCCESS(true, 2010, "이메일 인증을 완료했습니다."),
     MEMBER_EMAIL_VERIFY_FAIL(false, 2011, "이메일 인증에 실패했습니다."),
@@ -34,6 +35,9 @@ public enum BaseResponseMessage {
     MEMBER_LOGIN_SUCCESS(true, 2030, "로그인에 성공했습니다."),
     MEMBER_LOGIN_FAIL(false, 2031, "아이디 또는 비밀번호를 확인해주세요"),
     MEMBER_LOGIN_FAIL_NOT_FOUND(false, 2032, "사용자를 찾을 수 없습니다"),
+    // 계정 비활성화 2040
+    MEMBER_INACTIVE_SUCCESS(true, 2040, "계정 비활성화에 성공했습니다."),
+    MEMBER_INACTIVE_FAIL(false, 2041, "계정 비활성화에 실패했습니다."),
 
     // ========================================================================================================================
     // 팝업 스토어 3000

--- a/src/main/java/com/fiiiiive/zippop/member/EmailVerifyRepository.java
+++ b/src/main/java/com/fiiiiive/zippop/member/EmailVerifyRepository.java
@@ -2,9 +2,16 @@ package com.fiiiiive.zippop.member;
 
 import com.fiiiiive.zippop.member.model.EmailVerify;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface EmailVerifyRepository extends JpaRepository<EmailVerify, Long> {
     Optional<EmailVerify> findByEmail(String email);
+
+    @Modifying
+    @Query("DELETE FROM EmailVerify ev " +
+            "WHERE ev.email = :email")
+    int deleteByEmail(String email);
 }

--- a/src/main/java/com/fiiiiive/zippop/member/MemberController.java
+++ b/src/main/java/com/fiiiiive/zippop/member/MemberController.java
@@ -27,16 +27,25 @@ public class MemberController {
     public ResponseEntity<BaseResponse<PostSignupRes>> signup(@RequestBody PostSignupReq dto) throws Exception {
 
         PostSignupRes response = memberService.signup(dto);
-        String uuid = memberService.sendEmail(dto);
+        String uuid = memberService.sendEmail(response);
         emailVerifyService.save(dto.getEmail(), uuid);
         return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.MEMBER_REGISTER_SUCCESS, response));
     }
 
     @GetMapping("/verify")
     public ResponseEntity<BaseResponse> verify(String email, String role, String uuid) throws Exception, BaseException {
-        emailVerifyService.isExist(email, uuid);
-        memberService.activeMember(email, role);
-        return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.MEMBER_EMAIL_VERIFY_SUCCESS));
+        if(emailVerifyService.isExist(email, uuid)){
+            memberService.activeMember(email, role);
+            return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.MEMBER_EMAIL_VERIFY_SUCCESS));
+        } else {
+            return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.MEMBER_EMAIL_VERIFY_FAIL));
+        }
+    }
+
+    @GetMapping("/inactive")
+    public ResponseEntity<BaseResponse> inactive(@AuthenticationPrincipal CustomUserDetails customUserDetails) throws Exception, BaseException {
+        memberService.inActiveMenber(customUserDetails);
+        return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.MEMBER_INACTIVE_SUCCESS));
     }
 
 }

--- a/src/main/java/com/fiiiiive/zippop/member/MemberService.java
+++ b/src/main/java/com/fiiiiive/zippop/member/MemberService.java
@@ -3,16 +3,17 @@ package com.fiiiiive.zippop.member;
 import com.fiiiiive.zippop.common.exception.BaseException;
 import com.fiiiiive.zippop.common.responses.BaseResponseMessage;
 import com.fiiiiive.zippop.member.model.Company;
+import com.fiiiiive.zippop.member.model.CustomUserDetails;
 import com.fiiiiive.zippop.member.model.Customer;
 import com.fiiiiive.zippop.member.model.request.PostSignupReq;
 import com.fiiiiive.zippop.member.model.response.PostSignupRes;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.MailException;
-import org.springframework.mail.MailParseException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -25,6 +26,7 @@ public class MemberService {
     private final JavaMailSender emailSender;
     private final CompanyRepository companyRepository;
     private final CustomerRepository customerRepository;
+    private final EmailVerifyRepository emailVerifyRepository;
     private final PasswordEncoder passwordEncoder;
 
     public PostSignupRes signup(PostSignupReq request) throws BaseException {
@@ -32,38 +34,70 @@ public class MemberService {
             if(customerRepository.findByEmail(request.getEmail()).isPresent()) {
                 throw new BaseException(BaseResponseMessage.MEMBER_REGISTER_FAIL_ALREADY_REGISTER_AS_CUSTOMER);
             }
-            Company company = Company.builder()
-                    .email(request.getEmail())
-                    .password(passwordEncoder.encode(request.getPassword()))
-                    .name(request.getName())
-                    .crn(request.getCrn())
-                    .role(request.getRole())
-                    .enabled(false)
-                    .build();
-            companyRepository.save(company);
-            return PostSignupRes.builder()
-                    .idx(company.getCompanyIdx())
-                    .role(request.getRole())
-                    .email(request.getEmail())
-                    .build();
+            Optional<Company> result = companyRepository.findByEmail(request.getEmail());
+            if(result.isPresent()){
+                Company company = result.get();
+                if(company.getEnabled()) {
+                    throw new BaseException(BaseResponseMessage.MEMBER_REGISTER_FAIL_ALREADY_EXIST);
+                } else {
+                    return PostSignupRes.builder()
+                            .idx(company.getCompanyIdx())
+                            .enabled(company.getEnabled())
+                            .role(request.getRole())
+                            .email(request.getEmail())
+                            .build();
+                }
+            } else{
+                Company company = Company.builder()
+                        .email(request.getEmail())
+                        .password(passwordEncoder.encode(request.getPassword()))
+                        .name(request.getName())
+                        .crn(request.getCrn())
+                        .role(request.getRole())
+                        .enabled(false)
+                        .build();
+                companyRepository.save(company);
+                return PostSignupRes.builder()
+                        .idx(company.getCompanyIdx())
+                        .role(request.getRole())
+                        .enabled(company.getEnabled())
+                        .email(request.getEmail())
+                        .build();
+            }
         } else {
             if(companyRepository.findByEmail(request.getEmail()).isPresent()) {
                 throw new BaseException(BaseResponseMessage.MEMBER_REGISTER_FAIL_ALREADY_REGISTER_AS_COMPANY);
             }
-            Customer customer = Customer.builder()
-                    .email(request.getEmail())
-                    .password(passwordEncoder.encode(request.getPassword()))
-                    .name(request.getName())
-                    .role(request.getRole())
-                    .point(3000)
-                    .enabled(false)
-                    .build();
-            customerRepository.save(customer);
-            return PostSignupRes.builder()
-                    .idx(customer.getCustomerIdx())
-                    .role(request.getRole())
-                    .email(request.getEmail())
-                    .build();
+            Optional<Customer> result = customerRepository.findByEmail(request.getEmail());
+            if(result.isPresent()){
+                Customer customer = result.get();
+                if(customer.getEnabled()) {
+                    throw new BaseException(BaseResponseMessage.MEMBER_REGISTER_FAIL_ALREADY_EXIST);
+                } else {
+                    return PostSignupRes.builder()
+                            .idx(customer.getCustomerIdx())
+                            .role(request.getRole())
+                            .enabled(customer.getEnabled())
+                            .email(request.getEmail())
+                            .build();
+                }
+            } else {
+                Customer customer = Customer.builder()
+                        .email(request.getEmail())
+                        .password(passwordEncoder.encode(request.getPassword()))
+                        .name(request.getName())
+                        .role(request.getRole())
+                        .point(3000)
+                        .enabled(false)
+                        .build();
+                customerRepository.save(customer);
+                return PostSignupRes.builder()
+                        .idx(customer.getCustomerIdx())
+                        .role(request.getRole())
+                        .enabled(customer.getEnabled())
+                        .email(request.getEmail())
+                        .build();
+            }
         }
     }
 
@@ -90,14 +124,53 @@ public class MemberService {
         return true;
     }
 
-    public String sendEmail(PostSignupReq dto) throws MailException, Exception {
+    public String sendEmail(PostSignupRes response) throws MailException, Exception {
         SimpleMailMessage message = new SimpleMailMessage();
-        message.setTo(dto.getEmail());
-        if(Objects.equals(dto.getRole(), "ROLE_COMPANY")){ message.setSubject("ZIPPOP에 기업으로 가입하신걸 환영합니다."); }
-        else { message.setSubject("ZIPPOP에 회원으로 가입하신걸 환영합니다."); }
+        message.setTo(response.getEmail());
+        if(Objects.equals(response.getRole(), "ROLE_COMPANY")){
+            if(response.getEnabled()){
+                message.setSubject("ZIPPOP - 기업으로 가입하신걸 환영합니다.");
+            } else {
+                message.setSubject("ZIPPOP - 기업회원계정 복구 이메일");
+            }
+        }
+        else {
+            if(response.getEnabled()){
+                message.setSubject("ZIPPOP - 고객으로 가입하신걸 환영합니다.");
+            } else {
+                message.setSubject("ZIPPOP - 고객회원계정 복구 이메일");
+            }
+        }
         String uuid = UUID.randomUUID().toString();
-        message.setText("http://localhost:8080/api/v1/member/verify?email="+dto.getEmail()+"&role="+dto.getRole()+"&uuid="+uuid);
+        message.setText("http://localhost:8080/api/v1/member/verify?email="+response.getEmail()+"&role="+response.getRole()+"&uuid="+uuid);
         emailSender.send(message);
         return uuid;
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public void inActiveMenber(CustomUserDetails customUserDetails) throws BaseException {
+        String email = customUserDetails.getEmail();
+        String role = customUserDetails.getRole();
+        if(Objects.equals(role, "ROLE_COMPANY")){
+            Optional<Company> result = companyRepository.findByEmail(email);
+            if(result.isPresent()){
+                Company company = result.get();
+                company.setEnabled(false);
+                companyRepository.save(company);
+                emailVerifyRepository.deleteByEmail(email);
+            } else {
+                throw new BaseException(BaseResponseMessage.MEMBER_INACTIVE_FAIL);
+            }
+        } else {
+            Optional<Customer> result = customerRepository.findByEmail(customUserDetails.getEmail());
+            if(result.isPresent()) {
+                Customer customer = result.get();
+                customer.setEnabled(false);
+                customerRepository.save(customer);
+                emailVerifyRepository.deleteByEmail(email);
+            } else {
+                throw new BaseException(BaseResponseMessage.MEMBER_INACTIVE_FAIL);
+            }
+        }
     }
 }

--- a/src/main/java/com/fiiiiive/zippop/member/model/response/PostSignupRes.java
+++ b/src/main/java/com/fiiiiive/zippop/member/model/response/PostSignupRes.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class PostSignupRes {
     private Long idx;
+    private Boolean enabled;
     private String role;
     private String email;
 }

--- a/src/main/java/com/fiiiiive/zippop/popup_store/PopupStoreController.java
+++ b/src/main/java/com/fiiiiive/zippop/popup_store/PopupStoreController.java
@@ -1,5 +1,6 @@
 package com.fiiiiive.zippop.popup_store;
 
+import com.fiiiiive.zippop.common.annotation.ExeTimer;
 import com.fiiiiive.zippop.member.model.CustomUserDetails;
 import com.fiiiiive.zippop.popup_store.model.request.CreatePopupStoreReq;
 import com.fiiiiive.zippop.popup_store.model.response.GetPopupStoreRes;
@@ -19,6 +20,7 @@ import java.util.Optional;
 public class PopupStoreController {
     private final PopupStoreService popupStoreService;
 
+    @ExeTimer
     @PostMapping("/register")
     public ResponseEntity<String> register(@AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestBody CreatePopupStoreReq createPopupStoreReq) {
         popupStoreService.register(customUserDetails, createPopupStoreReq);


### PR DESCRIPTION
기업, 고객 회원 탈퇴 기능 구현
기업과 고객 회원의 테이블 enable을 0 으로 바꾸고 emailverify 테이블에서 해당 이메일을 찾아 삭제
다시 회원 가입시 복구 이메일이 전송되고 복구 이메일을 누르면 enable이 1로 변경되고 emailverify 저장 