### PR TITLE
[Feat] CUSER_008 완료, CUSER_004 완료, CUSER_005 진행

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,10 @@ dependencies {
 	implementation 'com.github.iamport:iamport-rest-client-java:0.2.23'
 	implementation 'com.google.code.gson:gson'
 
+	// Oauth
+	implementation 'com.google.code.gson:gson'
+	implementation 'org.springframework.security:spring-security-oauth2-client'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/fiiiiive/zippop/common/responses/BaseResponseMessage.java
+++ b/src/main/java/com/fiiiiive/zippop/common/responses/BaseResponseMessage.java
@@ -38,9 +38,10 @@ public enum BaseResponseMessage {
     // 계정 비활성화 2040
     MEMBER_INACTIVE_SUCCESS(true, 2040, "계정 비활성화에 성공했습니다."),
     MEMBER_INACTIVE_FAIL(false, 2041, "계정 비활성화에 실패했습니다."),
-    // 계정 비활성화 2040
+    // 계정 정보 수정 2050
     MEMBER_EDIT_INFO_SUCCESS(true, 2050, "계정 프로필 정보 변경에 성공했습니다."),
     MEMBER_EDIT_INFO_FAIL(false, 2051, "계정 프로필 정보 변경에 실패했습니다."),
+
     // 계정 패스워드 수정 2060
     MEMBER_EDIT_PASSWORD_SUCCESS(true, 2050, "계정 비밀번호 변경에 성공했습니다."),
     MEMBER_EDIT_PASSWORD_FAIL(false, 2051, "계정 비밀번호 변경에 실패했습니다."),

--- a/src/main/java/com/fiiiiive/zippop/common/responses/BaseResponseMessage.java
+++ b/src/main/java/com/fiiiiive/zippop/common/responses/BaseResponseMessage.java
@@ -39,6 +39,15 @@ public enum BaseResponseMessage {
     MEMBER_INACTIVE_SUCCESS(true, 2040, "계정 비활성화에 성공했습니다."),
     MEMBER_INACTIVE_FAIL(false, 2041, "계정 비활성화에 실패했습니다."),
 
+    // 계정 정보 수정 2050
+    MEMBER_EDIT_INFO_SUCCESS(true, 2050, "계정 프로필 정보 변경에 성공했습니다."),
+    MEMBER_EDIT_INFO_FAIL(false, 2051, "계정 프로필 정보 변경에 실패했습니다."),
+
+    // 계정 패스워드 수정 2060
+    MEMBER_EDIT_PASSWORD_SUCCESS(true, 2050, "계정 비밀번호 변경에 성공했습니다."),
+    MEMBER_EDIT_PASSWORD_FAIL(false, 2051, "계정 비밀번호 변경에 실패했습니다."),
+    MEMBER_EDIT_PASSWORD_FAIL_PASSWORD_NOT_MATCH(false, 2052, "계정 비밃번호가 틀립니다."),
+
     // ========================================================================================================================
     // 팝업 스토어 3000
     // 팝업 스토어 등록 3000

--- a/src/main/java/com/fiiiiive/zippop/common/responses/BaseResponseMessage.java
+++ b/src/main/java/com/fiiiiive/zippop/common/responses/BaseResponseMessage.java
@@ -38,6 +38,13 @@ public enum BaseResponseMessage {
     // 계정 비활성화 2040
     MEMBER_INACTIVE_SUCCESS(true, 2040, "계정 비활성화에 성공했습니다."),
     MEMBER_INACTIVE_FAIL(false, 2041, "계정 비활성화에 실패했습니다."),
+    // 계정 비활성화 2040
+    MEMBER_EDIT_INFO_SUCCESS(true, 2050, "계정 프로필 정보 변경에 성공했습니다."),
+    MEMBER_EDIT_INFO_FAIL(false, 2051, "계정 프로필 정보 변경에 실패했습니다."),
+    // 계정 패스워드 수정 2060
+    MEMBER_EDIT_PASSWORD_SUCCESS(true, 2050, "계정 비밀번호 변경에 성공했습니다."),
+    MEMBER_EDIT_PASSWORD_FAIL(false, 2051, "계정 비밀번호 변경에 실패했습니다."),
+    MEMBER_EDIT_PASSWORD_FAIL_PASSWORD_NOT_MATCH(false, 2052, "계정 비밃번호가 틀립니다."),
 
     // ========================================================================================================================
     // 팝업 스토어 3000

--- a/src/main/java/com/fiiiiive/zippop/config/filter/LoginFilter.java
+++ b/src/main/java/com/fiiiiive/zippop/config/filter/LoginFilter.java
@@ -50,12 +50,10 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     // 그림에서 10번
     @Override
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException, ServletException {
-        CustomUserDetails user = (CustomUserDetails)authResult.getPrincipal();
-        Collection<? extends GrantedAuthority> authorities = authResult.getAuthorities();
-        GrantedAuthority auth = authorities.iterator().next();
-        Long idx = user.getIdx();
-        String username = user.getUsername();
-        String role = auth.getAuthority();
+        CustomUserDetails member = (CustomUserDetails)authResult.getPrincipal();
+        Long idx = member.getIdx();
+        String username = member.getUsername();
+        String role = member.getRole();
         String token = jwtUtil.createToken(idx, username, role);
         log.info(idx + " " + role + " " + username);
         response.addHeader("Authorization", "Bearer " + token);

--- a/src/main/java/com/fiiiiive/zippop/config/filter/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/fiiiiive/zippop/config/filter/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,45 @@
+package com.fiiiiive.zippop.config.filter;
+
+import com.fiiiiive.zippop.member.model.CustomOauth2UserDetails;
+import com.fiiiiive.zippop.utils.JwtUtil;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        CustomOauth2UserDetails oAuth2Member = (CustomOauth2UserDetails) authentication.getPrincipal();
+        Long idx = oAuth2Member.getIdx();
+        String username = oAuth2Member.getUsername();
+        String role = oAuth2Member.getCustomer().getRole();
+        String token = jwtUtil.createToken(idx, username, role);
+        log.info(idx + " " + role + " " + username);
+        response.addHeader("Authorization", "Bearer " + token);
+        PrintWriter out = response.getWriter();
+        out.println("{\"username\":\"" + username + "\", \"isSuccess\": true, \"accessToken\": \"" + token + "\"}");
+//        String token = jwtUtil.createToken(10L, email, "ROLE_CUSTOMER");
+//        log.info(10L + " " + role + " " + email);
+//        response.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+//        Cookie aToken = new Cookie("OAuthToken", token);
+//        aToken.setHttpOnly(true);
+//        aToken.setSecure(true);
+//        aToken.setPath("/");
+//        aToken.setMaxAge(60 * 60 * 1);
+//        response.addCookie(aToken);
+//        getRedirectStrategy().sendRedirect(request, response, "http://localhost/test.html");
+    }
+}

--- a/src/main/java/com/fiiiiive/zippop/member/CustomOAuth2Service.java
+++ b/src/main/java/com/fiiiiive/zippop/member/CustomOAuth2Service.java
@@ -1,0 +1,52 @@
+package com.fiiiiive.zippop.member;
+
+import com.fiiiiive.zippop.member.model.CustomOauth2UserDetails;
+import com.fiiiiive.zippop.member.model.Customer;
+import com.fiiiiive.zippop.member.model.KakaoUserDetails;
+import com.fiiiiive.zippop.member.model.OAuth2UserInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2Service extends DefaultOAuth2UserService {
+    private final CustomerRepository customerRepository;
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        log.info("getAttributes : {}",oAuth2User.getAttributes());
+        String provider = userRequest.getClientRegistration().getRegistrationId();
+        OAuth2UserInfo oAuth2UserInfo = null;
+        if(provider.equals("kakao")){
+            log.info("카카오 로그인");
+            oAuth2UserInfo = new KakaoUserDetails(oAuth2User.getAttributes());
+        }
+        String email = oAuth2UserInfo.getEmail();
+        String name = oAuth2UserInfo.getName();
+        String role = "ROLE_CUSTOMER";
+        log.info(email + " " + name + " " + role);
+        Optional<Customer> result = customerRepository.findByEmail(email);
+        Customer customer = null;
+        if(result.isEmpty()){
+            customer = Customer.builder()
+                    .role(role)
+                    .name(name)
+                    .email(email)
+                    .point(3000)
+                    .enabled(true)
+                    .build();
+            customerRepository.save(customer);
+        } else {
+            customer = result.get();
+        }
+        return new CustomOauth2UserDetails(customer, oAuth2User.getAttributes());
+    }
+}

--- a/src/main/java/com/fiiiiive/zippop/member/MemberController.java
+++ b/src/main/java/com/fiiiiive/zippop/member/MemberController.java
@@ -4,6 +4,8 @@ import com.fiiiiive.zippop.common.exception.BaseException;
 import com.fiiiiive.zippop.common.responses.BaseResponse;
 import com.fiiiiive.zippop.common.responses.BaseResponseMessage;
 import com.fiiiiive.zippop.member.model.CustomUserDetails;
+import com.fiiiiive.zippop.member.model.request.EditInfoReq;
+import com.fiiiiive.zippop.member.model.request.EditPasswordReq;
 import com.fiiiiive.zippop.member.model.request.PostSignupReq;
 import com.fiiiiive.zippop.member.model.response.PostSignupRes;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -25,7 +27,6 @@ public class MemberController {
 
     @PostMapping("/signup")
     public ResponseEntity<BaseResponse<PostSignupRes>> signup(@RequestBody PostSignupReq dto) throws Exception {
-
         PostSignupRes response = memberService.signup(dto);
         String uuid = memberService.sendEmail(response);
         emailVerifyService.save(dto.getEmail(), uuid);
@@ -48,4 +49,15 @@ public class MemberController {
         return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.MEMBER_INACTIVE_SUCCESS));
     }
 
+    @PatchMapping("/edit-info")
+    public ResponseEntity<BaseResponse> editInfo(@AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestBody EditInfoReq dto) throws BaseException {
+        memberService.editInfo(customUserDetails, dto);
+        return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.MEMBER_EDIT_INFO_SUCCESS));
+    }
+
+    @PatchMapping("/edit-password")
+    public ResponseEntity<BaseResponse> editPassword(@AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestBody EditPasswordReq dto) throws BaseException {
+        memberService.editPassword(customUserDetails, dto);
+        return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.MEMBER_EDIT_PASSWORD_SUCCESS));
+    }
 }

--- a/src/main/java/com/fiiiiive/zippop/member/MemberController.java
+++ b/src/main/java/com/fiiiiive/zippop/member/MemberController.java
@@ -1,9 +1,10 @@
 package com.fiiiiive.zippop.member;
-import com.fiiiiive.zippop.common.annotation.ExeTimer;
 import com.fiiiiive.zippop.common.exception.BaseException;
 import com.fiiiiive.zippop.common.responses.BaseResponse;
 import com.fiiiiive.zippop.common.responses.BaseResponseMessage;
 import com.fiiiiive.zippop.member.model.CustomUserDetails;
+import com.fiiiiive.zippop.member.model.request.EditInfoReq;
+import com.fiiiiive.zippop.member.model.request.EditPasswordReq;
 import com.fiiiiive.zippop.member.model.request.PostSignupReq;
 import com.fiiiiive.zippop.member.model.response.PostSignupRes;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -24,7 +25,7 @@ public class MemberController {
     private final EmailVerifyService emailVerifyService;
 
     @PostMapping("/signup")
-    public ResponseEntity<BaseResponse<PostSignupRes>> signup(@RequestBody PostSignupReq dto) throws Exception {
+    public ResponseEntity<BaseResponse<PostSignupRes>> signup(@RequestBody PostSignupReq dto) throws BaseException {
 
         PostSignupRes response = memberService.signup(dto);
         String uuid = memberService.sendEmail(response);
@@ -33,7 +34,7 @@ public class MemberController {
     }
 
     @GetMapping("/verify")
-    public ResponseEntity<BaseResponse> verify(String email, String role, String uuid) throws Exception, BaseException {
+    public ResponseEntity<BaseResponse> verify(String email, String role, String uuid) throws BaseException {
         if(emailVerifyService.isExist(email, uuid)){
             memberService.activeMember(email, role);
             return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.MEMBER_EMAIL_VERIFY_SUCCESS));
@@ -43,9 +44,21 @@ public class MemberController {
     }
 
     @GetMapping("/inactive")
-    public ResponseEntity<BaseResponse> inactive(@AuthenticationPrincipal CustomUserDetails customUserDetails) throws Exception, BaseException {
+    public ResponseEntity<BaseResponse> inactive(@AuthenticationPrincipal CustomUserDetails customUserDetails) throws BaseException {
         memberService.inActiveMenber(customUserDetails);
         return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.MEMBER_INACTIVE_SUCCESS));
+    }
+
+    @PatchMapping("/edit-info")
+    public ResponseEntity<BaseResponse> editInfo(@AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestBody EditInfoReq dto) throws BaseException {
+        memberService.editInfo(customUserDetails, dto);
+        return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.MEMBER_EDIT_INFO_SUCCESS));
+    }
+
+    @PatchMapping("/edit-password")
+    public ResponseEntity<BaseResponse> editPassword(@AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestBody EditPasswordReq dto) throws BaseException {
+        memberService.editPassword(customUserDetails, dto);
+        return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.MEMBER_EDIT_PASSWORD_SUCCESS));
     }
 
 }

--- a/src/main/java/com/fiiiiive/zippop/member/model/Company.java
+++ b/src/main/java/com/fiiiiive/zippop/member/model/Company.java
@@ -24,6 +24,8 @@ public class Company {
     private String name;
     // 사업자 등록 번호(Company Registration Number)
     private String crn;
+    private String phoneNumber;
+    private String address;
     private Boolean enabled;
     private String role;
     @OneToMany(mappedBy = "company")

--- a/src/main/java/com/fiiiiive/zippop/member/model/Company.java
+++ b/src/main/java/com/fiiiiive/zippop/member/model/Company.java
@@ -24,9 +24,12 @@ public class Company {
     private String name;
     // 사업자 등록 번호(Company Registration Number)
     private String crn;
+    private String phoneNumber;
+    private String address;
     private Boolean enabled;
     private String role;
     @OneToMany(mappedBy = "company")
     @JsonManagedReference
     private List<PopupStore> popupStoreList = new ArrayList<>();
 }
+

--- a/src/main/java/com/fiiiiive/zippop/member/model/CustomOauth2UserDetails.java
+++ b/src/main/java/com/fiiiiive/zippop/member/model/CustomOauth2UserDetails.java
@@ -1,0 +1,79 @@
+package com.fiiiiive.zippop.member.model;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+@Getter
+public class CustomOauth2UserDetails implements UserDetails, OAuth2User {
+
+    private final Customer customer;
+    private Map<String, Object> attributes;
+
+    public CustomOauth2UserDetails(Customer customer, Map<String, Object> attributes) {
+        this.customer = customer;
+        this.attributes = attributes;
+    }
+
+    public Long getIdx(){
+        return customer.getCustomerIdx();
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+        collection.add(new GrantedAuthority() {
+            @Override
+            public String getAuthority() {
+                return customer.getRole();
+            }
+        });
+        return collection;
+    }
+
+    @Override
+    public String getPassword() {
+        return customer.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return customer.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return customer.getEnabled();
+    }
+
+}

--- a/src/main/java/com/fiiiiive/zippop/member/model/Customer.java
+++ b/src/main/java/com/fiiiiive/zippop/member/model/Customer.java
@@ -23,12 +23,10 @@ public class Customer {
     private Long customerIdx;
     @Column(nullable = false, length = 100, unique = true)
     private String email;
-    @Column(nullable = false, length = 100, unique = true)
     private String password;
     private String name;
     private String phoneNumber;
-    private String address1;
-    private String address2;
+    private String address;
     private Integer point;
     private String role;
     private Boolean enabled;

--- a/src/main/java/com/fiiiiive/zippop/member/model/Customer.java
+++ b/src/main/java/com/fiiiiive/zippop/member/model/Customer.java
@@ -26,8 +26,7 @@ public class Customer {
     private String password;
     private String name;
     private String phoneNumber;
-    private String address1;
-    private String address2;
+    private String address;
     private Integer point;
     private String role;
     private Boolean enabled;

--- a/src/main/java/com/fiiiiive/zippop/member/model/KakaoUserDetails.java
+++ b/src/main/java/com/fiiiiive/zippop/member/model/KakaoUserDetails.java
@@ -1,0 +1,32 @@
+package com.fiiiiive.zippop.member.model;
+
+
+import lombok.AllArgsConstructor;
+
+import java.util.Map;
+
+@AllArgsConstructor
+public class KakaoUserDetails implements OAuth2UserInfo {
+    private Map<String, Object> attributes;
+
+    @Override
+    public String getProvider() {
+        return "kakao";
+    }
+
+    @Override
+    public String getProviderId() {
+        return attributes.get("id").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) ((Map) attributes.get("kakao_account")).get("email");
+    }
+
+    @Override
+    public String getName() {
+        return (String) ((Map) attributes.get("properties")).get("nickname");
+    }
+
+}

--- a/src/main/java/com/fiiiiive/zippop/member/model/OAuth2UserInfo.java
+++ b/src/main/java/com/fiiiiive/zippop/member/model/OAuth2UserInfo.java
@@ -1,0 +1,8 @@
+package com.fiiiiive.zippop.member.model;
+
+public interface OAuth2UserInfo {
+    String getProvider();
+    String getProviderId();
+    String getEmail();
+    String getName();
+}

--- a/src/main/java/com/fiiiiive/zippop/member/model/request/EditInfoReq.java
+++ b/src/main/java/com/fiiiiive/zippop/member/model/request/EditInfoReq.java
@@ -1,4 +1,5 @@
 package com.fiiiiive.zippop.member.model.request;
+
 import lombok.*;
 
 @Getter
@@ -6,10 +7,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class PostSignupReq {
-    private String role;
-    private String email;
-    private String password;
+public class EditInfoReq {
     private String name;
     private String crn; // 사업자 등록 번호(Company Registration Number
     private String phoneNumber;

--- a/src/main/java/com/fiiiiive/zippop/member/model/request/EditInfoReq.java
+++ b/src/main/java/com/fiiiiive/zippop/member/model/request/EditInfoReq.java
@@ -1,0 +1,15 @@
+package com.fiiiiive.zippop.member.model.request;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EditInfoReq {
+    private String name;
+    private String crn; // 사업자 등록 번호(Company Registration Number
+    private String phoneNumber;
+    private String address;
+}

--- a/src/main/java/com/fiiiiive/zippop/member/model/request/EditPasswordReq.java
+++ b/src/main/java/com/fiiiiive/zippop/member/model/request/EditPasswordReq.java
@@ -1,0 +1,14 @@
+package com.fiiiiive.zippop.member.model.request;
+
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EditPasswordReq {
+    private String originPassword;
+    private String newPassword;
+}

--- a/src/main/java/com/fiiiiive/zippop/member/model/request/PostSignupReq.java
+++ b/src/main/java/com/fiiiiive/zippop/member/model/request/PostSignupReq.java
@@ -12,4 +12,6 @@ public class PostSignupReq {
     private String password;
     private String name;
     private String crn; // 사업자 등록 번호(Company Registration Number
+    private String phoneNumber;
+    private String address;
 }

--- a/src/main/java/com/fiiiiive/zippop/test/TestController.java
+++ b/src/main/java/com/fiiiiive/zippop/test/TestController.java
@@ -3,10 +3,12 @@ package com.fiiiiive.zippop.test;
 import com.fiiiiive.zippop.common.exception.BaseException;
 import com.fiiiiive.zippop.common.responses.BaseResponse;
 import com.fiiiiive.zippop.common.responses.BaseResponseMessage;
+import com.fiiiiive.zippop.member.model.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
@@ -33,5 +35,11 @@ public class TestController {
     @RequestMapping(method = RequestMethod.GET, value = "/base-exception")
     public ResponseEntity<BaseResponse> baseException() throws BaseException {
         throw new BaseException(BaseResponseMessage.REQUEST_FAIL);
+    }
+
+    @Operation(summary = "userInfo")
+    @RequestMapping(method = RequestMethod.GET, value = "/userInfo")
+    public ResponseEntity<BaseResponse> userInfo(@AuthenticationPrincipal CustomUserDetails customUserDetails) throws BaseException {
+        return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.REQUEST_SUCCESS, customUserDetails));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,26 @@ spring:
           connectiontimeout: 5000
           timeout: 5000
           writetimeout: 5000
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            authorization-grant-type: authorization_code
+            client-authentication-method: none
+            client-name: Kakao
+            scope:
+              - profile_nickname
+        #              - account_email
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
 logging:
   level:
     org.hibernate.SQL: debug


### PR DESCRIPTION
Oauth2
- CustomeOauth2UserDetails, Service로 정보를 저장하고
- SecurityFilter에 Oauth2 인증 기능 추가
- 카카오 소셜 로그인 구현 OAuthUserInfo 구현체를 상속받은 KakaoUserDetails
- 추후 구글 소셜 로그인 구현시 GoogleUserDetails 추가

회원정보수정
- 회원가입시 입력받지 못한 내용(주소, 전화번호)을 저장하거나 업데이트
- 비밀번호 변경 가능 (현재 비밀번호 + 새비밀번호) 서비스단에서 검증해 새로 저장

고객 마이페이지 
- 탈퇴 기능 구현됨, 찜 목록 조회 기능 구현
- 포인트 및, 예약 내역 조회는 진행 중

Customer 엔티티 변경
- Oauth2 인증시 password 값은 null이기 때문에 nullable, unique 해제

